### PR TITLE
feat: prop force in setPage

### DIFF
--- a/packages/boring-table-core/src/plugins/pagination.ts
+++ b/packages/boring-table-core/src/plugins/pagination.ts
@@ -43,8 +43,8 @@ export class PaginationPlugin<
     this.table.dispatch('update:extensions');
   }
 
-  setPage(page: number) {
-    if (page < 1 || page > this.totalPages) return;
+  setPage(page: number, force?: boolean) {
+    if ((page < 1 || page > this.totalPages) && !force) return;
     this.page = page;
     this.table.dispatch('update:custom-body');
     this.table.dispatch('update:extensions');


### PR DESCRIPTION
New property (optional) added to setPage (pagination): `force?: boolean`

If force is true, even if the page number is greater than the total number of pages, the page will be updated

Required to create pagination logic (current page to be updated) when choosing a new pageSize smaller than the previous one


